### PR TITLE
[dev] Fix ServiceX conf file generation; testing coffea-casa dev instance without xrd-authz-plugin

### DIFF
--- a/coffea_casa/jobqueue-coffea-casa.yaml
+++ b/coffea_casa/jobqueue-coffea-casa.yaml
@@ -5,7 +5,7 @@ jobqueue:
     cores: 2                 # Total number of cores per job
     memory: "6 GiB"                # Total amount of memory per job
     processes: null                # Number of Python processes per jobs
-    worker-image: "coffeateam/coffea-casa-analysis:2021.06.08post0"
+    worker-image: "coffeateam/coffea-casa-analysis:2021.06.20"
 
     # Comunication settings
     interface: null             # Network interface to use like eth0 or ib0

--- a/docker/coffea-casa-analysis/Dockerfile
+++ b/docker/coffea-casa-analysis/Dockerfile
@@ -94,14 +94,14 @@ RUN pip install --ignore-installed --no-cache-dir \
     git+git://github.com/oshadura/distributed.git@2021.06.0-coffea-casa#egg=distributed
 
 # ------- xrootd-authz-plugin -------------------------------
-RUN cd /tmp && \
-    git clone https://github.com/bbockelm/xrdcl-authz-plugin.git && \
-    cd xrdcl-authz-plugin && \
-    mkdir build && \
-    cd  build && \
-    cmake /tmp/xrdcl-authz-plugin -DCMAKE_INSTALL_PREFIX=/opt/conda && \
-    make && \
-    make install
+#RUN cd /tmp && \
+#    git clone https://github.com/bbockelm/xrdcl-authz-plugin.git && \
+#    cd xrdcl-authz-plugin && \
+#    mkdir build && \
+#    cd  build && \
+#    cmake /tmp/xrdcl-authz-plugin -DCMAKE_INSTALL_PREFIX=/opt/conda && \
+#    make && \
+#    make install
 
 USER root
 # Setup supervisord files
@@ -124,9 +124,9 @@ RUN groupadd -r condor && \
 
 # xcache setup (we setup BEARER_TOKEN_FILE later in prepare-env.sh)
 ENV XCACHE_HOST="red-xcache1.unl.edu"
-ENV XRD_PLUGINCONFDIR="/opt/conda/etc/xrootd/client.plugins.d/"
+#ENV XRD_PLUGINCONFDIR="/opt/conda/etc/xrootd/client.plugins.d/"
 ENV LD_LIBRARY_PATH="/opt/conda/lib/:$LD_LIBRARY_PATH"
-ENV XRD_PLUGIN="/opt/conda/lib/libXrdClAuthzPlugin.so"
+#ENV XRD_PLUGIN="/opt/conda/lib/libXrdClAuthzPlugin.so"
 ENV BEARER_TOKEN_FILE="/etc/xcache_token"
 ENV PATH="/opt/conda/bin/:$PATH"
 ENV PYTHONPATH="$HOME/.local/lib/python3.8/site-packages:$PYTHONPATH"

--- a/docker/coffea-casa/Dockerfile
+++ b/docker/coffea-casa/Dockerfile
@@ -194,15 +194,15 @@ RUN pip install --ignore-installed --no-cache-dir \
 
 
 # ------- xrootd-authz-plugin -------------------------------
-RUN cd /tmp && \
-    # ------- xrdcl-authz-plugin -------------------------------
-    git clone https://github.com/bbockelm/xrdcl-authz-plugin.git && \
-    cd xrdcl-authz-plugin && \
-    mkdir build && \
-    cd  build && \
-    cmake /tmp/xrdcl-authz-plugin -DCMAKE_INSTALL_PREFIX=/opt/conda && \
-    make && \
-    make install
+#RUN cd /tmp && \
+#    # ------- xrdcl-authz-plugin -------------------------------
+#    git clone https://github.com/bbockelm/xrdcl-authz-plugin.git && \
+#    cd xrdcl-authz-plugin && \
+#    mkdir build && \
+#    cd  build && \
+#    cmake /tmp/xrdcl-authz-plugin -DCMAKE_INSTALL_PREFIX=/opt/conda && \
+#    make && \
+#    make install
 
 USER root
 # Dask setup - > dask.yml
@@ -246,7 +246,7 @@ RUN rm -rf /tmp/* \
 ENV XCACHE_HOST="red-xcache1.unl.edu"
 ENV XRD_PLUGINCONFDIR="/opt/conda/etc/xrootd/client.plugins.d/"
 ENV LD_LIBRARY_PATH="/opt/conda/lib/:$LD_LIBRARY_PATH"
-ENV XRD_PLUGIN="/opt/conda/lib/libXrdClAuthzPlugin.so"
+#ENV XRD_PLUGIN="/opt/conda/lib/libXrdClAuthzPlugin.so"
 ENV BEARER_TOKEN_FILE="/etc/cmsaf-secrets/xcache_token"
 ENV PATH="/opt/conda/bin/:$PATH"
 ENV PYTHONPATH="$HOME/.local/lib/python3.8/site-packages:$PYTHONPATH"

--- a/docker/coffea-casa/jobqueue-coffea-casa.yaml
+++ b/docker/coffea-casa/jobqueue-coffea-casa.yaml
@@ -5,7 +5,7 @@ jobqueue:
     cores: 2                 # Total number of cores per job
     memory: "6 GiB"                # Total amount of memory per job
     processes: null                # Number of Python processes per jobs
-    worker-image: "coffeateam/coffea-casa-analysis:2021.06.08post0"
+    worker-image: "coffeateam/coffea-casa-analysis:2021.06.20"
 
     # Comunication settings
     interface: null             # Network interface to use like eth0 or ib0

--- a/docker/coffea-casa/prepare-env.sh
+++ b/docker/coffea-casa/prepare-env.sh
@@ -8,25 +8,25 @@ export PYTHONPATH="$HOME/.local/lib/python3.8/site-packages:$PYTHONPATH"
 if [[ -f "/etc/cmsaf-secrets/.servicex" ]] && [[ "$SERVICEX_HOST" ]]; then
     export servicex_token=$(</etc/cmsaf-secrets/.servicex)
     touch $HOME/.servicex
-    echo "Tokens: generating ServiceX config file."
+    echo "Tokens: generating ServiceX config file (available only from Jupyterhub notebook)"
     echo "
 api_endpoints:
   - endpoint: $SERVICEX_HOST
-    token:
     type: uproot
     " > $HOME/.servicex
 
-    /opt/conda/bin/python -c '
-import yaml, os
-servicex="$HOME/.servicex"
-with open(servicex) as f:
-    list_yaml=yaml.load(f,Loader=yaml.Loader)
-list_yaml["api_endpoints"][0]["token"] = os.environ.get("servicex_token")
-with open(servicex, "w") as f:
-    yaml.dump(list_yaml,f)'
+### No need to add tokens until now (when revert please add "token:" in .servicex template)
+#    /opt/conda/bin/python -c '
+#import yaml, os
+#servicex="$HOME/.servicex"
+#with open(servicex) as f:
+#    list_yaml=yaml.load(f,Loader=yaml.Loader)
+#list_yaml["api_endpoints"][0]["token"] = os.environ.get("servicex_token")
+#with open(servicex, "w") as f:
+#    yaml.dump(list_yaml,f)'
 
-    echo "Tokens: ServiceX config file was succesfully generated."
-    unset servicex_token
+#    echo "Tokens: ServiceX config file was succesfully generated."
+#    unset servicex_token
 fi
 
 if [ -e "$HOME/environment.yml" ]; then

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,4 +4,4 @@ import coffea_casa.config
 
 
 def test_dask_config():
-    assert dask.config.get('jobqueue.coffea-casa.worker-image') == "coffeateam/coffea-casa-analysis:2021.06.08post0"
+    assert dask.config.get('jobqueue.coffea-casa.worker-image') == "coffeateam/coffea-casa-analysis:2021.06.20"


### PR DESCRIPTION
- ServiceX is available only from JH notebook for now
- testing coffea-casa dev instance without xrd-authz-plugin (with this setup xcache is disabled, but I need to find regression for combination of xrd-authz-plugin+xrootd5.2.0)