### PR TITLE
Add DistributedEnvironmentPlugin

### DIFF
--- a/coffea_casa/__init__.py
+++ b/coffea_casa/__init__.py
@@ -5,6 +5,7 @@ import dask
 import yaml
 import os
 from .coffea_casa import CoffeaCasaCluster
+from .plugin import DistributedEnvironmentPlugin
 from . import config
 
 from ._version import get_versions

--- a/coffea_casa/plugin.py
+++ b/coffea_casa/plugin.py
@@ -10,6 +10,7 @@ from dask.utils import tmpfile
 
 logger = logging.getLogger(__name__)
 
+
 class DistributedEnvironmentPlugin(NannyPlugin):
     """A NannyPlugin to upload a local pip installable package to workers.
     Parameters
@@ -89,11 +90,9 @@ class DistributedEnvironmentPlugin(NannyPlugin):
 
         # Now try to pip install the package
         package_path = os.path.join(nanny.local_directory,self.package)
-        logger.info("Installing the package: %s",self.package);
+        logger.info("Installing the package: %s",self.package)
         proc = subprocess.Popen(
-            [sys.executable, "-m", "pip", "install"]
-            + self.pip_options
-            + [package_path],
+            [sys.executable, "-m", "pip", "install"] + self.pip_options + [package_path],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
@@ -103,7 +102,7 @@ class DistributedEnvironmentPlugin(NannyPlugin):
         if returncode:
             logger.error("Pip install failed with '%s'",stderr.decode().strip())
             return
-        
+
         # Cleanup the zip file
         logger.info("Cleaning up temporary directory: %s",fn)
         os.remove(fn)
@@ -115,7 +114,7 @@ class DistributedEnvironmentPlugin(NannyPlugin):
             logger.info(f"Removing: {fname}")
             path = os.path.join(nanny.local_directory,fname)
             os.remove(path)
-        logger.info("Uninstalling the package: %s",self.package);
+        logger.info("Uninstalling the package: %s",self.package)
         proc = subprocess.Popen(
             [sys.executable, "-m", "pip", "uninstall", self.package],
             stdout=subprocess.PIPE,
@@ -123,3 +122,9 @@ class DistributedEnvironmentPlugin(NannyPlugin):
         )
         stdout, stderr = proc.communicate()
         returncode = proc.wait()
+
+        if returncode:
+            logger.error("Pip uninstall failed with '%s'",stderr.decode().strip())
+            return
+
+        return

--- a/coffea_casa/plugin.py
+++ b/coffea_casa/plugin.py
@@ -1,0 +1,125 @@
+import os
+import sys
+import zipfile
+import logging
+import uuid
+import subprocess
+
+from distributed.diagnostics.plugin import NannyPlugin
+from dask.utils import tmpfile
+
+logger = logging.getLogger(__name__)
+
+class DistributedEnvironmentPlugin(NannyPlugin):
+    """A NannyPlugin to upload a local pip installable package to workers.
+    Parameters
+    ----------
+    path: str
+        A path to the pip installable directory to upload
+    Examples
+    --------
+    >>> from distributed.diagnostics.plugin import DistributedEnvironmentPlugin
+    >>> client.register_worker_plugin(DistributedEnvironmentPlugin("/path/to/directory"), nanny=True)  # doctest: +SKIP
+    """
+
+    def __init__(
+        self,
+        path,
+        pip_options=None,
+        restart=False,
+        update_path=False,
+        skip_words=(".git", ".github", ".pytest_cache", "tests", "docs"),
+        skip=(lambda fn: os.path.splitext(fn)[1] == ".pyc",),
+        extra_inputs=[],
+    ):
+        """
+        Initialize the plugin by reading in the data from the given file.
+        """
+        path = os.path.expanduser(path)
+        self.package = os.path.split(path)[-1]
+        self.restart = restart
+        self.update_path = update_path
+        if pip_options is None:
+            pip_options = []
+        self.pip_options = pip_options
+        self.extra_inputs = [os.path.split(x)[-1] for x in extra_inputs]
+
+        self.name = "upload-directory-" + self.package
+
+        with tmpfile(extension="zip") as fn:
+            with zipfile.ZipFile(fn, "w", zipfile.ZIP_DEFLATED) as z:
+                for root, dirs, files in os.walk(path):
+                    for file in files:
+                        filename = os.path.join(root, file)
+                        if any(predicate(filename) for predicate in skip):
+                            continue
+                        dirs = filename.split(os.sep)
+                        if any(word in dirs for word in skip_words):
+                            continue
+
+                        archive_name = os.path.relpath(
+                            os.path.join(root, file), os.path.join(path, "..")
+                        )
+                        z.write(filename, archive_name)
+                for fpath in extra_inputs:
+                    fname = os.path.split(fpath)[-1]
+                    z.write(fpath,fname)
+
+            with open(fn, "rb") as f:
+                self.data = f.read()
+
+    def setup(self, nanny):
+        # Copy the package to the worker machine
+        logger.info("Entering plugin setup")
+        logger.info("nanny.local_directory: %s",nanny.local_directory)
+        logger.info("nanny.worker_dir: %s",nanny.worker_dir)
+        fn = os.path.join(nanny.local_directory, f"tmp-{str(uuid.uuid4())}.zip")
+        with open(fn, "wb") as f:
+            f.write(self.data)
+
+        with zipfile.ZipFile(fn) as z:
+            z.extractall(path=nanny.local_directory)
+
+        if self.update_path:
+            if nanny.local_directory not in sys.path:
+                sys.path.insert(0, nanny.local_directory)
+            path = os.path.join(nanny.local_directory, self.package)
+            if path not in sys.path:
+                sys.path.insert(0, path)
+
+        # Now try to pip install the package
+        package_path = os.path.join(nanny.local_directory,self.package)
+        logger.info("Installing the package: %s",self.package);
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "pip", "install"]
+            + self.pip_options
+            + [package_path],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stdout, stderr = proc.communicate()
+        returncode = proc.wait()
+
+        if returncode:
+            logger.error("Pip install failed with '%s'",stderr.decode().strip())
+            return
+        
+        # Cleanup the zip file
+        logger.info("Cleaning up temporary directory: %s",fn)
+        os.remove(fn)
+
+        return
+
+    def teardown(self, nanny):
+        for fname in self.extra_inputs:
+            logger.info(f"Removing: {fname}")
+            path = os.path.join(nanny.local_directory,fname)
+            os.remove(path)
+        logger.info("Uninstalling the package: %s",self.package);
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "pip", "uninstall", self.package],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stdout, stderr = proc.communicate()
+        returncode = proc.wait()


### PR DESCRIPTION
Addresses #219 by including a new [plugins.py](https://github.com/Andrew42/coffea-casa/blob/dep-nanny-plugin/coffea_casa/plugin.py) file that provides a `NannyPlugin` that can install a locally specified pip installable package. The plugin can also be provided a list of individual python files (e.g. analysis specific processor definitions) that should be included alongside the main package.

This PR does not currently include a corresponding `pytest` test as it is unclear how to best setup the inputs for a useful unit test. I plan to make a github issue, which will link back to this PR, regarding the need for such a test, so that we don't forget.

There are a few other parts of coffea-casa that I would like to get feedback on if they should also be modified in this PR. These are related to the changes needed to actually enable the use of `NannyPlugin`s in general.

1. The coffea-casa [Dockerfile](https://github.com/CoffeaTeam/coffea-casa/blob/master/docker/coffea-casa-analysis-cc7/Dockerfile#L167) should presumably enable John's patch for `dask.distributed`.
2. The [patch](https://github.com/CoffeaTeam/coffea-casa/blob/master/docker/coffea-casa-analysis-cc7/distributed/0005-Add-patch-from-John-Thiltges.patch) file itself needs to be regenerated to work with newer versions of `dask.distributed`. We've already remade the patch during testing (e.g. [here](https://github.com/Andrew42/dask-custom-docker/blob/main/distributed/0005-Add-patch-from-John-Thiltges.patch)), but I'd like to get confirmation on which version of `distributed` is currently being used in coffea-casa to know if the updated patch should be used or not.
3. [coffea_casa.py](https://github.com/CoffeaTeam/coffea-casa/blob/master/coffea_casa/coffea_casa.py) has a number of nanny related lines commented out. I assume that we would want to uncomment these lines?