### PR TITLE
Update coffea-casa dask jobqueue cluster config file to match the new naming conventions in the recent dask_jobqueue release

### DIFF
--- a/coffea_casa/coffea_casa.py
+++ b/coffea_casa/coffea_casa.py
@@ -93,7 +93,7 @@ class CoffeaCasaCluster(HTCondorCluster):
             Total amount of memory per job (defaults to 6 GB).
         scheduler_options : dict
             Extra scheduler options for the job (Dask specific).
-        job_extra : dict
+        job_extra_directives : dict
             Extra submit file attributes for the job (HTCondor specific).
 
         Examples
@@ -180,7 +180,7 @@ class CoffeaCasaCluster(HTCondorCluster):
             ),
         )
         ## Job extra settings (HTCondor ClassAd)
-        job_config["job_extra"] = merge_dicts(
+        job_config["job_extra_directives"] = merge_dicts(
             {
                 "universe": "docker",
                 "docker_image": worker_image or dask.config.get(f"jobqueue.{cls.config_name}.worker-image")
@@ -201,7 +201,7 @@ class CoffeaCasaCluster(HTCondorCluster):
             {"Stream_Error": "False"},
             {"+DaskSchedulerAddress": external_ip_string},
             job_kwargs.get(
-                "job_extra", dask.config.get(f"jobqueue.{cls.config_name}.job-extra")
+                "job_extra_directives", dask.config.get(f"jobqueue.{cls.config_name}.job-extra-directives")
             ),
         )
         print(job_config)

--- a/docker/dask/jobqueue-coffea-casa.yaml
+++ b/docker/dask/jobqueue-coffea-casa.yaml
@@ -1,25 +1,32 @@
 jobqueue:
   coffea-casa:
-
+    name: dask-worker
     # Dask worker options, taken from https://github.com/dask/dask-jobqueue/tree/master/dask_jobqueue
     cores: 2                 # Total number of cores per job
     memory: "6 GiB"                # Total amount of memory per job
     processes: null                # Number of Python processes per jobs
+    
     worker-image: "hub.opensciencegrid.org/coffea-casa/cc-analysis-ubuntu:development"
 
     # Comunication settings
     interface: null             # Network interface to use like eth0 or ib0
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
     local-directory: null       # Location of fast local storage like /scratch or $TMPDIR
-    extra: []
+    shared-temp-directory: null
+    extra: null
+    worker-extra-args: []
 
     # HTCondor Resource Manager options
     disk: "5 GiB"          # Amount of disk per worker job
-    env-extra: []
-    job-extra: {}               # Extra submit attributes
+    env-extra: null
+    job-script-prologue: []
+    job-extra: null             # Extra submit attributes
+    job-extra-directives: {}    # Extra submit attributes
+    job-directives-skip: []
+    submit-command-extra: []    # Extra condor_submit arguments
+    cancel-command-extra: []    # Extra condor_rm arguments
     log-directory: null
     shebang: "#!/usr/bin/env condor_submit -spool"
 
     # Scheduler options
     scheduler-options: {}
-    name: dask-worker


### PR DESCRIPTION
Following the problem discovered in https://github.com/CoffeaTeam/lpcjobqueue/pull/12 (@nsmith- 👍 )