### PR TITLE
Add Dask jobqueue 0.7.4 support

### DIFF
--- a/coffea_casa/coffea_casa.py
+++ b/coffea_casa/coffea_casa.py
@@ -93,7 +93,7 @@ class CoffeaCasaCluster(HTCondorCluster):
             Total amount of memory per job (defaults to 6 GB).
         scheduler_options : dict
             Extra scheduler options for the job (Dask specific).
-        job_extra_directives : dict
+        job_extra : dict
             Extra submit file attributes for the job (HTCondor specific).
 
         Examples
@@ -180,7 +180,7 @@ class CoffeaCasaCluster(HTCondorCluster):
             ),
         )
         ## Job extra settings (HTCondor ClassAd)
-        job_config["job_extra_directives"] = merge_dicts(
+        job_config["job_extra"] = merge_dicts(
             {
                 "universe": "docker",
                 "docker_image": worker_image or dask.config.get(f"jobqueue.{cls.config_name}.worker-image")
@@ -201,7 +201,7 @@ class CoffeaCasaCluster(HTCondorCluster):
             {"Stream_Error": "False"},
             {"+DaskSchedulerAddress": external_ip_string},
             job_kwargs.get(
-                "job_extra_directives", dask.config.get(f"jobqueue.{cls.config_name}.job-extra-directives")
+                "job_extra", dask.config.get(f"jobqueue.{cls.config_name}.job-extra")
             ),
         )
         print(job_config)

--- a/coffea_casa/jobqueue-coffea-casa.yaml
+++ b/coffea_casa/jobqueue-coffea-casa.yaml
@@ -1,6 +1,6 @@
 jobqueue:
   coffea-casa:
-
+    name: dask-worker
     # Dask worker options, taken from https://github.com/dask/dask-jobqueue/tree/master/dask_jobqueue
     cores: 2                 # Total number of cores per job
     memory: "6 GiB"                # Total amount of memory per job
@@ -11,15 +11,17 @@ jobqueue:
     interface: null             # Network interface to use like eth0 or ib0
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
     local-directory: null       # Location of fast local storage like /scratch or $TMPDIR
+    shared-temp-directory: null       # Shared directory currently used to dump temporary security objects for workers
     extra: []
 
     # HTCondor Resource Manager options
     disk: "5 GiB"          # Amount of disk per worker job
     env-extra: []
     job-extra: {}               # Extra submit attributes
+    submit-command-extra: []    # Extra condor_submit arguments
+    cancel-command-extra: []    # Extra condor_rm arguments
     log-directory: null
     shebang: "#!/usr/bin/env condor_submit -spool"
 
     # Scheduler options
     scheduler-options: {}
-    name: dask-worker

--- a/docker/Dockerfile.cc-analysis-ubuntu
+++ b/docker/Dockerfile.cc-analysis-ubuntu
@@ -106,6 +106,7 @@ RUN pip install --no-cache-dir \
     servicex \
     func-adl-uproot \
     cabinetry \
+    dask_jobqueue==0.7.4 \
     aiostream
 
 # ------- xrootd-authz-plugin -------------------------------

--- a/docker/Dockerfile.cc-ubuntu
+++ b/docker/Dockerfile.cc-ubuntu
@@ -55,6 +55,7 @@ ENV CACHE_PREFIX=$CACHE_PREFIX
 
 USER ${NB_USER}    
 RUN pip install --no-cache-dir \
+    dask_jobqueue==0.7.4 \
     # funcx
     funcx==0.3.9 \
     # visualization

--- a/docker/dask/jobqueue-coffea-casa.yaml
+++ b/docker/dask/jobqueue-coffea-casa.yaml
@@ -1,25 +1,27 @@
 jobqueue:
   coffea-casa:
-
+    name: dask-worker
     # Dask worker options, taken from https://github.com/dask/dask-jobqueue/tree/master/dask_jobqueue
     cores: 2                 # Total number of cores per job
     memory: "6 GiB"                # Total amount of memory per job
     processes: null                # Number of Python processes per jobs
-    worker-image: "hub.opensciencegrid.org/coffea-casa/cc-analysis-ubuntu:development"
+    worker-image: "coffeateam/coffea-casa-analysis:latest"
 
     # Comunication settings
     interface: null             # Network interface to use like eth0 or ib0
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
     local-directory: null       # Location of fast local storage like /scratch or $TMPDIR
+    shared-temp-directory: null       # Shared directory currently used to dump temporary security objects for workers
     extra: []
 
     # HTCondor Resource Manager options
     disk: "5 GiB"          # Amount of disk per worker job
     env-extra: []
     job-extra: {}               # Extra submit attributes
+    submit-command-extra: []    # Extra condor_submit arguments
+    cancel-command-extra: []    # Extra condor_rm arguments
     log-directory: null
     shebang: "#!/usr/bin/env condor_submit -spool"
 
     # Scheduler options
     scheduler-options: {}
-    name: dask-worker

--- a/docker/dask/jobqueue-coffea-casa.yaml
+++ b/docker/dask/jobqueue-coffea-casa.yaml
@@ -1,32 +1,25 @@
 jobqueue:
   coffea-casa:
-    name: dask-worker
+
     # Dask worker options, taken from https://github.com/dask/dask-jobqueue/tree/master/dask_jobqueue
     cores: 2                 # Total number of cores per job
     memory: "6 GiB"                # Total amount of memory per job
     processes: null                # Number of Python processes per jobs
-    
     worker-image: "hub.opensciencegrid.org/coffea-casa/cc-analysis-ubuntu:development"
 
     # Comunication settings
     interface: null             # Network interface to use like eth0 or ib0
     death-timeout: 60           # Number of seconds to wait if a worker can not find a scheduler
     local-directory: null       # Location of fast local storage like /scratch or $TMPDIR
-    shared-temp-directory: null
-    extra: null
-    worker-extra-args: []
+    extra: []
 
     # HTCondor Resource Manager options
     disk: "5 GiB"          # Amount of disk per worker job
-    env-extra: null
-    job-script-prologue: []
-    job-extra: null             # Extra submit attributes
-    job-extra-directives: {}    # Extra submit attributes
-    job-directives-skip: []
-    submit-command-extra: []    # Extra condor_submit arguments
-    cancel-command-extra: []    # Extra condor_rm arguments
+    env-extra: []
+    job-extra: {}               # Extra submit attributes
     log-directory: null
     shebang: "#!/usr/bin/env condor_submit -spool"
 
     # Scheduler options
     scheduler-options: {}
+    name: dask-worker


### PR DESCRIPTION
For now, we are limited with `dask-jobqueue`==0.7.4. Moving to `dask-jobqueue`==0.8.0 will require updating the `coffea_casa` configuration (we have a chance to improve it!).