### PR TITLE
For PyHEP we are going to use dask_jobqueue 0.7.3

### DIFF
--- a/docker/Dockerfile.cc-analysis-ubuntu
+++ b/docker/Dockerfile.cc-analysis-ubuntu
@@ -106,7 +106,7 @@ RUN pip install --no-cache-dir \
     servicex \
     func-adl-uproot \
     cabinetry \
-    dask_jobqueue==0.7.4 \
+    dask_jobqueue==0.7.3 \
     aiostream
 
 # ------- xrootd-authz-plugin -------------------------------

--- a/docker/Dockerfile.cc-ubuntu
+++ b/docker/Dockerfile.cc-ubuntu
@@ -55,7 +55,7 @@ ENV CACHE_PREFIX=$CACHE_PREFIX
 
 USER ${NB_USER}    
 RUN pip install --no-cache-dir \
-    dask_jobqueue==0.7.4 \
+    dask_jobqueue==0.7.3 \
     # funcx
     funcx==0.3.9 \
     # visualization


### PR DESCRIPTION
Looks like there were some changes in codebase which is incompatible to our current setup (we need more testing)

It will be expected to be fixed with https://github.com/CoffeaTeam/coffea-casa/issues/337