### PR TITLE
Switch conda for mamba in docker images

### DIFF
--- a/docker/prepare-env/prepare-env-cc-analysis.sh
+++ b/docker/prepare-env/prepare-env-cc-analysis.sh
@@ -4,7 +4,7 @@ set -x
 
 if [ "$EXTRA_CONDA_PACKAGES" ]; then
     echo "conda: EXTRA_CONDA_PACKAGES environment variable found.  Installing."
-    /opt/conda/bin/conda install -y $EXTRA_CONDA_PACKAGES
+    /opt/conda/bin/mamba install -y $EXTRA_CONDA_PACKAGES
 fi
 
 if [ "$EXTRA_PIP_PACKAGES" ]; then
@@ -81,10 +81,10 @@ if [[ ! -v COFFEA_CASA_SIDECAR ]]; then
   
   if [ -e "$_CONDOR_JOB_IWD/environment.yml" ]; then
     echo "Conda: environment.yml found. Installing packages."
-    /opt/conda/bin/conda env update -n base -f $_CONDOR_JOB_IWD/environment.yml
+    /opt/conda/bin/mamba env update -n base -f $_CONDOR_JOB_IWD/environment.yml
   elif [ -e "$_CONDOR_JOB_IWD/environment.yaml" ]; then
     echo "Conda: environment.yaml found. Installing packages."
-    /opt/conda/bin/conda env update -n base -f $_CONDOR_JOB_IWD/environment.yaml
+    /opt/conda/bin/mamba env update -n base -f $_CONDOR_JOB_IWD/environment.yaml
   else
     echo "No environment.yml, conda will not install any package."
   fi

--- a/docker/prepare-env/prepare-env-cc-base.sh
+++ b/docker/prepare-env/prepare-env-cc-base.sh
@@ -16,10 +16,10 @@ echo "SCHEDD_HOST = ${SCHEDD_HOST}" >> /opt/condor/config.d/schedd
 # Check environment
 if [ -e "$HOME/environment.yml" ]; then
     echo "Conda: environment.yml found. Installing packages."
-    /opt/conda/bin/conda env update -f $HOME/environment.yml
+    /opt/conda/bin/mamba env update -f $HOME/environment.yml
   elif [ -e "$HOME/environment.yaml" ]; then
     echo "Conda: environment.yaml found. Installing packages."
-    /opt/conda/bin/conda env update -f $HOME/environment.yaml
+    /opt/conda/bin/mamba env update -f $HOME/environment.yaml
   else
     echo "No environment.yml, conda will not install any package."
   fi
@@ -33,7 +33,7 @@ if [ -e "$HOME/environment.yml" ]; then
 
 if [ "$EXTRA_CONDA_PACKAGES" ]; then
     echo "conda: EXTRA_CONDA_PACKAGES environment variable found.  Installing."
-    /opt/conda/bin/conda install -y $EXTRA_CONDA_PACKAGES
+    /opt/conda/bin/mamba install -y $EXTRA_CONDA_PACKAGES
 fi
 
 if [ "$EXTRA_PIP_PACKAGES" ]; then

--- a/docker/prepare-env/prepare-env-cc.sh
+++ b/docker/prepare-env/prepare-env-cc.sh
@@ -62,10 +62,10 @@ fi
 # Check environment
 if [ -e "$HOME/environment.yml" ]; then
     echo "Conda: environment.yml found. Installing packages."
-    /opt/conda/bin/conda env update -f $HOME/environment.yml
+    /opt/conda/bin/mamba env update -f $HOME/environment.yml
   elif [ -e "$HOME/environment.yaml" ]; then
     echo "Conda: environment.yaml found. Installing packages."
-    /opt/conda/bin/conda env update -f $HOME/environment.yaml
+    /opt/conda/bin/mamba env update -f $HOME/environment.yaml
   else
     echo "No environment.yml, conda will not install any package."
   fi
@@ -79,7 +79,7 @@ if [ -e "$HOME/environment.yml" ]; then
 
 if [ "$EXTRA_CONDA_PACKAGES" ]; then
     echo "conda: EXTRA_CONDA_PACKAGES environment variable found.  Installing."
-    /opt/conda/bin/conda install -y $EXTRA_CONDA_PACKAGES
+    /opt/conda/bin/mamba install -y $EXTRA_CONDA_PACKAGES
 fi
 
 if [ "$EXTRA_PIP_PACKAGES" ]; then


### PR DESCRIPTION
Mamba seems to run significantly faster than conda. In testing, conda estimated ~45 hours to solve dependencies for an install, while mamba finished in 47 seconds.