### PR TITLE
fix: Require cabinetry v0.5.1+

### DIFF
--- a/docker/Dockerfile.cc-analysis-centos7
+++ b/docker/Dockerfile.cc-analysis-centos7
@@ -115,7 +115,10 @@ RUN mamba install --yes \
     hist \
     mplhep \
     iminuit \
-    cmake
+    cmake \
+    && mamba clean \
+        --all \
+        --yes
 
 #
 RUN pip install --no-cache-dir coffea[servicex] \
@@ -177,7 +180,6 @@ RUN rm -rf ${CONDA_DIR}/condabin && ln -s ${CONDA_DIR}/bin ${CONDA_DIR}/condabin
 # Cleanup
 RUN rm -rf /tmp/* \
     && rm -rf $HOME/.cache/.pip/* \
-    && mamba clean -tipsy \
     && find ${CONDA_DIR} -type f -name '*.a' -delete \
     && find ${CONDA_DIR} -type f -name '*.pyc' -delete \
     && find ${CONDA_DIR} -type f -name '*.js.map' -delete \

--- a/docker/Dockerfile.cc-analysis-centos7
+++ b/docker/Dockerfile.cc-analysis-centos7
@@ -110,6 +110,7 @@ RUN mamba install --yes \
     oidc-agent \
     xgboost \
     pyhf \
+    cabinetry>=0.5.1 \
     vector \
     hist \
     mplhep \
@@ -121,8 +122,7 @@ RUN pip install --no-cache-dir coffea[servicex] \
     # for running/restarting Dask worker in sidecar container
     supervisor \
     correctionlib \
-    func_adl_uproot \
-    cabinetry
+    func_adl_uproot
 
 # ------- xrootd-authz-plugin -------------------------------
 #RUN cd /tmp && \

--- a/docker/Dockerfile.cc-analysis-ubuntu
+++ b/docker/Dockerfile.cc-analysis-ubuntu
@@ -92,6 +92,7 @@ RUN mamba install --yes \
     htcondor \
     xgboost \
     pyhf \
+    cabinetry>=0.5.1 \
     vector \
     hist \
     mplhep \
@@ -105,7 +106,6 @@ RUN pip install --no-cache-dir \
     func-adl-servicex \
     servicex \
     func-adl-uproot \
-    cabinetry \
     dask_jobqueue==0.7.3 \
     tornado==6.2 \
     aiostream

--- a/docker/Dockerfile.cc-analysis-ubuntu
+++ b/docker/Dockerfile.cc-analysis-ubuntu
@@ -97,7 +97,11 @@ RUN mamba install --yes \
     hist \
     mplhep \
     iminuit \
-    cmake
+    cmake \
+    && mamba clean \
+        --all \
+        --force-pkgs-dirs \
+        --yes
 
 #
 RUN pip install --no-cache-dir \
@@ -158,7 +162,6 @@ RUN rm -rf /opt/conda/condabin && ln -s /opt/conda/bin /opt/conda/condabin
 # Cleanup
 RUN rm -rf /tmp/* \
     && rm -rf $HOME/.cache/.pip/* \
-    && mamba clean --all -f -y \
     && find /opt/conda/ -type f,l -name '*.a' -delete \
     && find /opt/conda/ -type f,l -name '*.pyc' -delete \
     && find /opt/conda/ -type f,l -name '*.js.map' -delete \

--- a/docker/Dockerfile.cc-base-centos7
+++ b/docker/Dockerfile.cc-base-centos7
@@ -47,7 +47,7 @@ ENV SCHEDD_HOST $SCHEDD_HOST
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
-     
+
 # Install all OS dependencies for notebook server that starts but lacks all
 # features (e.g., download as all possible file formats)
 RUN yum -y install http://opensource.wandisco.com/centos/7/git/x86_64/wandisco-git-release-7-2.noarch.rpm \
@@ -189,6 +189,7 @@ RUN mamba install --yes \
     htcondor \
     xgboost \
     pyhf \
+    cabinetry>=0.5.1 \
     vector \
     hist \
     mplhep \
@@ -204,7 +205,6 @@ RUN pip install --no-cache-dir \
     tcut_to_qastle \
     servicex-databinder \
     correctionlib \
-    cabinetry \
     func_adl_uproot \
     tcut_to_qastle \
     servicex-databinder \

--- a/docker/Dockerfile.cc-base-centos7
+++ b/docker/Dockerfile.cc-base-centos7
@@ -128,7 +128,9 @@ RUN mamba install --quiet --yes \
     jupyterlab_widgets \
     jupyterlab-git \
     dask_labextension && \
-    mamba clean -tipsy && \
+    mamba clean \
+        --all \
+        --yes && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \
     jupyter lab clean && \
@@ -195,7 +197,10 @@ RUN mamba install --yes \
     mplhep \
     iminuit \
     cmake \
-    scikit-hep-testdata
+    scikit-hep-testdata \
+    && mamba clean \
+        --all \
+        --yes
 
 RUN pip install --no-cache-dir \
     aiostream \
@@ -229,7 +234,6 @@ RUN groupadd -r condor && \
 # Cleanup
 RUN rm -rf /tmp/* \
     && rm -rf $HOME/.cache/.pip/* \
-    && mamba clean -tipsy \
     && jupyter lab clean \
     && jlpm cache clean \
     && npm cache clean --force \

--- a/docker/Dockerfile.cc-base-ubuntu
+++ b/docker/Dockerfile.cc-base-ubuntu
@@ -47,7 +47,7 @@ ENV CONDOR_HOST $CONDOR_HOST
 ENV COLLECTOR_NAME $COLLECTOR_NAME
 ENV UID_DOMAIN $UID_DOMAIN
 ENV SCHEDD_HOST $SCHEDD_HOST
-     
+
 # Install all OS dependencies for notebook server that starts but lacks all
 # features (e.g., download as all possible file formats)
 RUN apt-get update --yes && \
@@ -206,6 +206,7 @@ RUN mamba install --yes \
     htcondor \
     xgboost \
     pyhf \
+    cabinetry>=0.5.1 \
     vector \
     hist \
     mplhep \
@@ -224,7 +225,6 @@ RUN pip install --no-cache-dir \
     # Packages depends on the older version of servicex
     servicex-databinder \
     correctionlib \
-    cabinetry \
     #funcx==0.3.9 \
     pyyaml
     #git+https://github.com/ssl-hep/servicex-labextension.git#subdirectory=servicex-dashboard

--- a/docker/Dockerfile.cc-base-ubuntu
+++ b/docker/Dockerfile.cc-base-ubuntu
@@ -114,7 +114,10 @@ RUN mamba install --quiet --yes \
     jupyterlab_widgets \
     jupyterlab-git \
     dask_labextension && \
-    mamba clean --all -f -y && \
+    mamba clean \
+        --all \
+        --force-pkgs-dirs \
+        --yes && \
     npm cache clean --force && \
     jupyter notebook --generate-config && \
     jupyter lab clean && \
@@ -212,7 +215,11 @@ RUN mamba install --yes \
     mplhep \
     iminuit \
     cmake \
-    scikit-hep-testdata
+    scikit-hep-testdata \
+    && mamba clean \
+        --all \
+        --force-pkgs-dirs \
+        --yes
 
 RUN pip install --no-cache-dir \
     aiostream \
@@ -250,7 +257,6 @@ RUN groupadd -r condor && \
 # Cleanup
 RUN rm -rf /tmp/* \
     && rm -rf $HOME/.cache/.pip/* \
-    && mamba clean --all -f -y \
     && jupyter lab clean \
     && jlpm cache clean \
     && npm cache clean --force \


### PR DESCRIPTION
Resolves #344

* `cabinetry` `v0.5.0+` requires `pyhf` `v0.7.x` which requires `jsonschema>=4.15.0`. Use `mamba` for the install of `cabinetry` to consolidate as many of the library requirements into a single virtual environment.
* Perform all `mamba` clean actions in the same layer as mamba install to help decrease image size.
   - This is only applied to instances in which `mamba install` is used during the image build. If not, then instances of `mamba clean` are left in place to avoid noisy diffs that would be cosmetic to the image size.