### PR TITLE
fix: Use 'req@url' syntax to install from remote VCS

### DIFF
--- a/docs/cc_packages.rst
+++ b/docs/cc_packages.rst
@@ -44,7 +44,7 @@ To use this code for your own purposes, you merely have to put in your list of d
 
     dependency_installer = DependencyInstaller([
         "pytest",
-        "git+https://github.com/TopEFT/topcoffea.git#egg=topcoffea",
+        "topcoffea@git+https://github.com/TopEFT/topcoffea.git",
     ])
     
 and your workers should have both pytest and topcoffea installed onto them.

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(name='coffea_casa',
       zip_safe=False,
       long_description_content_type = 'text/markdown',
       setup_requires=["pytest-runner", "flake8"],
-      dependency_links=['git+git://github.com/oshadura/distributed.git@coffea-casa-facility#egg=distributed'],
+      dependency_links=['distributed@git+git://github.com/oshadura/distributed.git@coffea-casa-facility'],
       tests_require=TESTS_REQUIRE,
       classifiers=[
           "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(name='coffea_casa',
       zip_safe=False,
       long_description_content_type = 'text/markdown',
       setup_requires=["pytest-runner", "flake8"],
-      dependency_links=['distributed@git+git://github.com/oshadura/distributed.git@coffea-casa-facility'],
+      dependency_links=['distributed@git+https://github.com/oshadura/distributed.git@coffea-casa-facility'],
       tests_require=TESTS_REQUIRE,
       classifiers=[
           "Development Status :: 4 - Beta",


### PR DESCRIPTION
Use 'req@url' syntax when using pip to install from a remote git repository over 'url#egg=req' to avoid the use of #egg= fragments with a non-PEP 508 name. This will be required in pip v25.0+.
   - c.f. https://github.com/pypa/pip/pull/11617 for more details.

Also use `pip`'s `git+https` VCS scheme over `git+git` as recommended in the [`pip` docs on VCS Support](https://pip.pypa.io/en/stable/topics/vcs-support/):
> The use of `git`, `git+git`, and `git+http` schemes is discouraged. The former two use the Git Protocol, which lacks authentication, and HTTP is insecure due to lack of TLS based encryption.