### PR TITLE
Update packages docs to use dask.distributed.PipInstall

### DIFF
--- a/docs/cc_packages.rst
+++ b/docs/cc_packages.rst
@@ -19,33 +19,22 @@ If you install a package to your scheduler but attempt to run it on your workers
 
 .. code-block:: python
 
-    from dask.distributed import Client, Worker, WorkerPlugin
-    from typing import List
-    import os
+    from dask.distributed import Client, PipInstall
 
-    class DependencyInstaller(WorkerPlugin):
-        def __init__(self, dependencies: List[str]):
-            self._depencendies = " ".join(f"'{dep}'" for dep in dependencies)
-
-        def setup(self, worker: Worker):
-            os.system(f"pip install {self._depencendies}")
-
-
-    dependency_installer = DependencyInstaller([
+    dependencies = [
         "pytest",
-    ])
-
+    ]
     client = Client("tls://localhost:8786")
-    client.register_worker_plugin(dependency_installer)
+    client.register_worker_plugin(PipInstall(packages=dependencies))
     
-To use this code for your own purposes, you merely have to put in your list of dependencies in the ``dependency_installer``. This should support all installation formats that pip does, and you can add multiple packages by expanding the list. For example, to install a second package from a GitHub repository, you could specify:
+To use this code for your own purposes, you merely have to put in your dependencies in the ``dependencies`` list. This should support all installation formats that pip does, and you can add multiple packages by expanding the list. For example, to install a second package from a GitHub repository, you could specify:
 
 .. code-block:: python
 
-    dependency_installer = DependencyInstaller([
+    dependencies = [
         "pytest",
         "topcoffea@git+https://github.com/TopEFT/topcoffea.git",
-    ])
+    ]
     
 and your workers should have both pytest and topcoffea installed onto them.
 


### PR DESCRIPTION
Just a simpe update to use PipInstall now that it's available on coffea-casa. I use it [like this](https://github.com/btcardwell/SIDM/blob/4396c5a477b52dcf38e2994ae76f467b646b2db5/sidm/tools/scaleout.py) in my analysis repo.

Fix https://github.com/CoffeaTeam/coffea-casa/issues/375