### PR TITLE
fix: Require scipy v1.8.1+ from conda-forge

### DIFF
--- a/docker/Dockerfile.cc-analysis-centos7
+++ b/docker/Dockerfile.cc-analysis-centos7
@@ -110,6 +110,7 @@ RUN mamba install --yes \
     oidc-agent \
     xgboost \
     pyhf \
+    scipy>=1.8.1 \
     cabinetry>=0.5.1 \
     vector \
     hist \

--- a/docker/Dockerfile.cc-analysis-ubuntu
+++ b/docker/Dockerfile.cc-analysis-ubuntu
@@ -90,6 +90,7 @@ RUN mamba install --yes \
     htcondor \
     xgboost \
     pyhf \
+    scipy>=1.8.1 \
     cabinetry>=0.5.1 \
     vector \
     hist \

--- a/docker/Dockerfile.cc-base-centos7
+++ b/docker/Dockerfile.cc-base-centos7
@@ -192,6 +192,7 @@ RUN mamba install --yes \
     htcondor \
     xgboost \
     pyhf \
+    scipy>=1.8.1 \
     cabinetry>=0.5.1 \
     vector \
     hist \

--- a/docker/Dockerfile.cc-base-ubuntu
+++ b/docker/Dockerfile.cc-base-ubuntu
@@ -210,6 +210,7 @@ RUN mamba install --yes \
     htcondor \
     xgboost \
     pyhf \
+    scipy>=1.8.1 \
     cabinetry>=0.5.1 \
     vector \
     hist \


### PR DESCRIPTION
Resolves #379

Conda-forge `scipy` distributions seem to have a problem with optimizations that can cause `pyhf` inference to hang up to `scipy` `v1.8.1` where this seems to be resolved. This problem does NOT exist in wheel distributions on PyPI. To resolve this, simply set a lower bound on `scipy` of `v1.8.1`.