### PR TITLE
Add support for mlflow token to be shipped over condor

### DIFF
--- a/coffea_casa/coffea_casa.py
+++ b/coffea_casa/coffea_casa.py
@@ -35,6 +35,10 @@ if (HOME_DIR / "environment.yaml").is_file():
     CONDA_ENV = HOME_DIR / "environment.yaml"
 else:
     CONDA_ENV = HOME_DIR / "environment.yml"
+# Test dummy mlflow token
+if (HOME_DIR / "mlflow_token").is_file():
+    MLFLOW_FILE = HOME_DIR / "mlflow_token"
+
 
 
 def merge_dicts(*dict_args):
@@ -151,6 +155,8 @@ class CoffeaCasaCluster(HTCondorCluster):
             input_files += [XCACHE_SCITOKEN_FILE]
         if (XCACHE_FILE.is_file()):
             input_files += [XCACHE_FILE]
+        if (MLFLOW_FILE.is_file()):
+            input_files += [MLFLOW_FILE]
         else:
             raise KeyError("Please check with system administarator why you do not have a certificate.")
         files = ", ".join(str(path) for path in input_files)

--- a/docker/Dockerfile.cc-analysis-ubuntu
+++ b/docker/Dockerfile.cc-analysis-ubuntu
@@ -13,6 +13,9 @@ ARG GITHUB_ACTIONS="false"
 # FIX ME AFTER TEST:
 ARG BEARER_TOKEN_FILE="/home/$NB_USER/.xcache/access_token"
 ARG XCACHE_HOST="red-xcache1.unl.edu"
+# Test dummy mlflow token
+ARG MLFLOW_TOKEN="/home/$NB_USER/.mlflow/mlflow_token" 
+ARG MLFLOW_TRACKING_URI="https://mlflow-demo.software-dev.ncsa.illinois.edu"
 
 
 # Configure environment
@@ -27,6 +30,9 @@ ENV NB_UID $NB_UID
 ENV NB_GID $NB_GID
 ENV HOME /home/$NB_USER
 ENV PATH "/opt/conda/bin/:$PATH"
+# Test dummy mlflow token
+ENV MLFLOW_TOKEN=$MLFLOW_TOKEN
+ENV MLFLOW_TRACKING_URI=$MLFLOW_TRACKING_URI
 
 # Install all OS dependencies for notebook server that starts but lacks all
 # features (e.g., download as all possible file formats)
@@ -184,6 +190,9 @@ RUN cd /opt/conda/lib/python3.8/site-packages/distributed && \
 # cms-jovyan@jupyter-oksana-2eshadura-40cern-2ech:~$ echo $PATH
 # /opt/conda/condabin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games
 RUN rm -rf /opt/conda/condabin && ln -s /opt/conda/bin /opt/conda/condabin
+
+# mlflow
+ENV MLFLOW_TRACKING_TOKEN="$(cat $MLFLOW_TOKEN)"
 
 # Cleanup
 RUN rm -rf /tmp/* \

--- a/docker/Dockerfile.cc-ubuntu
+++ b/docker/Dockerfile.cc-ubuntu
@@ -35,6 +35,10 @@ ARG UID_DOMAIN="unl.edu"
 ARG SCHEDD_HOST="t3.unl.edu"
 # XCACHE
 ARG XCACHE_HOST="red-xcache1.unl.edu"
+# Test dummy mlflow token
+ARG MLFLOW_TOKEN="/home/cms-jovyan/mlflow_token" 
+ARG MLFLOW_TRACKING_URI="https://mlflow-demo.software-dev.ncsa.illinois.edu"
+
 
 # Hack for GH Actions
 ARG GITHUB_ACTIONS="false"
@@ -53,6 +57,9 @@ ENV CONDOR_HOST=$CONDOR_HOST
 ENV COLLECTOR_NAME=$COLLECTOR_NAME
 ENV UID_DOMAIN=$UID_DOMAIN
 ENV SCHEDD_HOST=$SCHEDD_HOST
+# Test dummy mlflow token
+ENV MLFLOW_TOKEN=$MLFLOW_TOKEN
+ENV MLFLOW_TRACKING_URI=$MLFLOW_TRACKING_URI
 
 USER ${NB_USER}    
 RUN pip install --no-cache-dir \
@@ -113,6 +120,9 @@ RUN ln -s /etc/grid-security/certificates/hcc-flatiron.pem /etc/grid-security/ce
 
 # Coffea_casa - > jobqueue-coffea-casa.yaml
 COPY dask/jobqueue-coffea-casa.yaml dask/dask_tls.yaml ${DASK_ROOT_CONFIG}/
+
+# mlflow
+ENV MLFLOW_TRACKING_TOKEN="$(cat $MLFLOW_TOKEN)"
 
 USER root
 

--- a/docker/prepare-env/prepare-env-cc-analysis.sh
+++ b/docker/prepare-env/prepare-env-cc-analysis.sh
@@ -71,8 +71,12 @@ if [[ ! -v COFFEA_CASA_SIDECAR ]]; then
       cp $_CONDOR_JOB_IWD/ceph.conf ${CEPH_DIR}
   fi
 
-    if [[ -f "$_CONDOR_JOB_IWD/access_token" ]]; then
+  if [[ -f "$_CONDOR_JOB_IWD/access_token" ]]; then
       mkdir -p /home/$NB_USER/.xcache && cp $_CONDOR_JOB_IWD/access_token  /home/$NB_USER/.xcache/access_token
+  fi
+
+  if [[ -f "$_CONDOR_JOB_IWD/mlflow_token" ]]; then
+      mkdir -p /home/$NB_USER/.mlflow && cp $_CONDOR_JOB_IWD/mlflow_token  /home/$NB_USER/..mlflow/mlflow_token
   fi
 
   if [[ -f "$_CONDOR_JOB_IWD/keyring" ]]; then


### PR DESCRIPTION
A simple test for custom CoffeaCasa dask cluster (it will possibly not work for Dask Labextention)
See: https://github.com/CoffeaTeam/coffea-casa/issues/349