### PR TITLE
add periodic `gc.collect()` callback to workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ _readthedocs
 **/charts/coffea-casa/charts
 **/Chart.lock
 
+# pyright lsp
+pyrightconfig.json


### PR DESCRIPTION
### **DO NOT MERGE**

We should test and fine-tune (especially the frequency argument) this periodic callback. 

This might be useful, because `dask` does call `gc.collect()` only during spilling or pausing, but that's likely [too late](https://github.com/dask/distributed/blob/main/distributed/worker_memory.py#L75)