### PR TITLE
update HOST - daskworker contact addr

### DIFF
--- a/docker/prepare-env/prepare-env-cc-analysis.sh
+++ b/docker/prepare-env/prepare-env-cc-analysis.sh
@@ -105,7 +105,8 @@ if [[ ! -v COFFEA_CASA_SIDECAR ]]; then
       #FIXME:
       #NANNY_PORT=`cat $_CONDOR_JOB_AD | grep nanny_HostPort | tr -d '"' | awk '{print $NF;}'`
       #NANNYCONTAINER_PORT=`cat $_CONDOR_JOB_AD | grep nanny_ContainerPort | tr -d '"' | awk '{print $NF;}'`
-      HOST=`cat $_CONDOR_JOB_AD | grep RemoteHost | tr -d '"' | tr '@' ' ' | awk '{print $NF;}'`
+      #HOST=`cat $_CONDOR_JOB_AD | grep RemoteHost | tr -d '"' | tr '@' ' ' | awk '{print $NF;}'`
+      HOST=`cat $_CONDOR_JOB_AD | grep StartdIpAddr | sed 's/StartdIpAddr = \"<\([^:]*\).*/\1/'`
       NAME=`cat $_CONDOR_JOB_AD | grep "DaskWorkerName "  | tr -d '"' | awk '{print $NF;}'`
       # Requirement: to add to Condor job decription "+DaskSchedulerAddress": '"tcp://129.93.183.34:8787"',
       EXTERNALIP_PORT=`cat $_CONDOR_JOB_AD | grep DaskSchedulerAddress | tr -d '"' | awk '{print $NF;}'`


### PR DESCRIPTION
We run HTCondor within Kubernetes, and when hostNetwork is not enabled, the RemoteHost reported by a Condor job defaults to the hostname of the worker node. However, what we actually need here is the IP address of the HTCondor pod itself.

Fortunately, this IP address is available via the StartdIpAddr classad. By utilizing StartdIpAddr, we ensure the Dask Worker has the correct contact address.

This change is designed to work seamlessly across different deployment scenarios—whether HTCondor is running outside Kubernetes, within Kubernetes with hostNetwork enabled, or in Kubernetes without hostNetwork.