### PR TITLE
add fix-permissions

### DIFF
--- a/docker/Dockerfile.cc-analysis-alma9
+++ b/docker/Dockerfile.cc-analysis-alma9
@@ -205,5 +205,8 @@ RUN mkdir /cvmfs
 ADD prepare-env/prepare-env-cc-analysis.sh /usr/local/bin/prepare-env.sh
 RUN chmod ugo+x /usr/local/bin/prepare-env.sh
 
+# Fix permission after all packages installations are done
+RUN fix-permissions "${CONDA_DIR}"
+
 USER $NB_USER
 ENTRYPOINT ["tini", "-g", "--", "/usr/local/bin/prepare-env.sh"]

--- a/docker/Dockerfile.cc-dask-alma9
+++ b/docker/Dockerfile.cc-dask-alma9
@@ -310,6 +310,9 @@ RUN chmod g-w /usr/local/etc/grid-security
 RUN chmod g-w /usr/local/etc/grid-security/*
 RUN chmod g-w /usr/local/etc/grid-security/certificates/*
 
+# Fix permission after all packages installations are done
+RUN fix-permissions "${CONDA_DIR}"
+
 # Switch back to cms-jovyan to avoid accidental container runs as root
 USER ${NB_UID}
 WORKDIR $HOME

--- a/docker/prepare-env/prepare-env-cc-analysis.sh
+++ b/docker/prepare-env/prepare-env-cc-analysis.sh
@@ -105,7 +105,8 @@ if [[ ! -v COFFEA_CASA_SIDECAR ]]; then
       #FIXME:
       #NANNY_PORT=`cat $_CONDOR_JOB_AD | grep nanny_HostPort | tr -d '"' | awk '{print $NF;}'`
       #NANNYCONTAINER_PORT=`cat $_CONDOR_JOB_AD | grep nanny_ContainerPort | tr -d '"' | awk '{print $NF;}'`
-      HOST=`cat $_CONDOR_JOB_AD | grep RemoteHost | tr -d '"' | tr '@' ' ' | awk '{print $NF;}'`
+      #HOST=`cat $_CONDOR_JOB_AD | grep RemoteHost | tr -d '"' | tr '@' ' ' | awk '{print $NF;}'`
+      HOST=`cat $_CONDOR_JOB_AD | grep StartdIpAddr | sed 's/StartdIpAddr = \"<\([^:]*\).*/\1/'`
       NAME=`cat $_CONDOR_JOB_AD | grep "DaskWorkerName "  | tr -d '"' | awk '{print $NF;}'`
       # Requirement: to add to Condor job decription "+DaskSchedulerAddress": '"tcp://129.93.183.34:8787"',
       EXTERNALIP_PORT=`cat $_CONDOR_JOB_AD | grep DaskSchedulerAddress | tr -d '"' | awk '{print $NF;}'`


### PR DESCRIPTION
We map user to local users.  So we need this fix-permission to run at a later stage so that the users can update those conda packages. 

```
$ ls -ld /usr/local/lib/python3.12/site-packages/numpy-1.26.4.dist-info/
drwxr-sr-x. 2 atlas-coffea atlas-coffea 4096 Mar  5 16:28 /usr/local/lib/python3.12/site-packages/numpy-1.26.4.dist-info/
$ groups
atlas-coffea
```