### PR TITLE
chore: update base image to coffeateam/coffea-dask-almalinux9-noml:2025.10.0-py3.12

### DIFF
--- a/docker/Dockerfile.cc-analysis-alma9
+++ b/docker/Dockerfile.cc-analysis-alma9
@@ -1,5 +1,5 @@
 #FROM coffeateam/coffea-base-almalinux8:0.7.22-py3.10
-FROM coffeateam/coffea-dask-almalinux9-noml:2025.9.0-py3.12
+FROM coffeateam/coffea-dask-almalinux9-noml:2025.10.0-py3.12
 
 
 USER root

--- a/docker/Dockerfile.cc-analysis-combine-alma9
+++ b/docker/Dockerfile.cc-analysis-combine-alma9
@@ -1,5 +1,5 @@
 #FROM coffeateam/coffea-base-almalinux8:0.7.22-py3.10
-FROM coffeateam/coffea-dask-almalinux9-noml:2025.9.0-py3.12
+FROM coffeateam/coffea-dask-almalinux9-noml:2025.10.0-py3.12
 
 
 USER root

--- a/docker/Dockerfile.cc-dask-alma9
+++ b/docker/Dockerfile.cc-dask-alma9
@@ -1,4 +1,4 @@
-FROM coffeateam/coffea-dask-almalinux9-noml:2025.9.0-py3.12
+FROM coffeateam/coffea-dask-almalinux9-noml:2025.10.0-py3.12
 
 # https://github.com/jupyter/docker-stacks/blob/master/base-notebook/Dockerfile
 

--- a/docker/Dockerfile.cc-dask-combine-alma9
+++ b/docker/Dockerfile.cc-dask-combine-alma9
@@ -1,4 +1,4 @@
-FROM coffeateam/coffea-dask-almalinux9-noml:2025.9.0-py3.12
+FROM coffeateam/coffea-dask-almalinux9-noml:2025.10.0-py3.12
 
 # https://github.com/jupyter/docker-stacks/blob/master/base-notebook/Dockerfile
 


### PR DESCRIPTION
A new Coffea image version has been detected.

This PR updates all Dockerfiles that use `coffeateam/coffea-dask-almalinux9-noml:<old>` to `coffeateam/coffea-dask-almalinux9-noml:2025.10.0-py3.12`.