### PR TITLE
docs: fix coffea links

### DIFF
--- a/docs/cc_user.rst
+++ b/docs/cc_user.rst
@@ -2,7 +2,7 @@ First Steps at Coffea-Casa @ UNL
 ==========================
 Prerequisites
 -------------
-The primary mode of analysis with coffea-casa is `coffea <https://coffeateam.github.io/coffea/index.html>`_. Coffea provides plenty of examples to users in its `documentation <https://coffeateam.github.io/coffea/examples.html>`_. Further resources, meant to run specifically on coffea-casa, can be found in the sidebar under the "Gallery of Coffea-casa Examples" section or the appropriate repository `here <https://github.com/CoffeaTeam/coffea-casa-tutorials>`_.
+The primary mode of analysis with coffea-casa is `coffea <https://coffea-hep.readthedocs.io>`_. Coffea provides plenty of examples to users in its `documentation <https://coffea-hep.readthedocs.io/en/latest/examples.html>`_. Further resources, meant to run specifically on coffea-casa, can be found in the sidebar under the "Gallery of Coffea-casa Examples" section or the appropriate repository `here <https://github.com/CoffeaTeam/coffea-casa-tutorials>`_.
 
 Knowledge of `Python <https://docs.python.org/3/tutorial/>`_ is assumed. The standard environment for coffea analyses is within `Jupyter Notebooks <https://jupyter.org/>`_, which allow for dynamic, block-by-block execution of code. Coffea-casa employs the `JupyterLab <https://jupyterlab.readthedocs.io/en/stable/user/interface.html>`_ interface. JupyterLab is designed for hosting Jupyter Notebooks on the web and permits the usage of additional features within its environment, including Git access, compatibility with cluster computing tools, and much, much more.
 

--- a/docs/gallery/analysis_tutorial.ipynb
+++ b/docs/gallery/analysis_tutorial.ipynb
@@ -36,7 +36,7 @@
     "\n",
     "\n",
     "<h2>Foundations</h2>\n",
-    "<p>For the purposes of this tutorial, we will load in a sample file used in the analysis, as well as NanoEvents from the Coffea package. A <a href=\"https://coffeateam.github.io/coffea/notebooks/nanoevents.html\">NanoEvents tutorial</a> is available which gives a detailed description, but I will give a quick exploration of how it can be used to access data.</p>"
+    "<p>For the purposes of this tutorial, we will load in a sample file used in the analysis, as well as NanoEvents from the Coffea package. A <a href=\"https://coffea-hep.readthedocs.io/en/latest/notebooks/nanoevents.html\">NanoEvents tutorial</a> is available which gives a detailed description, but I will give a quick exploration of how it can be used to access data.</p>"
    ]
   },
   {

--- a/docs/gallery/coffea-casa-template.ipynb
+++ b/docs/gallery/coffea-casa-template.ipynb
@@ -121,7 +121,7 @@
    "metadata": {},
    "source": [
     "### Specifications\n",
-    "This part is pure [Coffea](https://coffeateam.github.io/coffea/reference.html). The processor class encapsulates all of our analysis. It is what we send to our executor, which forwards it to our workers. For detailed instructions on how to create the processor class, see the Coffea examples and documentation, or refer to the benchmarks and analysis in this repository. In short:\n",
+    "This part is pure [Coffea](https://coffea-hep.readthedocs.io). The processor class encapsulates all of our analysis. It is what we send to our executor, which forwards it to our workers. For detailed instructions on how to create the processor class, see the Coffea examples and documentation, or refer to the benchmarks and analysis in this repository. In short:\n",
     "\n",
     "`__init__`: This is where we define our histograms. Categorical or sparse axes (*Cats*) split data vertically, into different categories. Bin or dense axes (*Bins*) split data horizontally, into the 'bars' of the histogram. We also define an accumulator here. Data that is fed to the Processor is split into chunks, and we need to add all of these chunks together to get a histogram of **all** chunks. The accumulator is a tool that allows us to do this, by enabling easy object addition; i.e., \\[AwkwardArray1\\] + \\[AwkwardArray2\\] = \\[AwkwardArray1 + AwkwardArray2\\].\n",
     "\n",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ The facility is built on top of a Kubernetes cluster and integrates with dedicat
    Why Dask? <https://docs.dask.org/en/latest/why.html>
    Dask-jobqueue introduction <https://jobqueue.dask.org/en/latest/howitworks.html>
    Dask-labextention introduction <https://pypi.org/project/dask-labextension/>
-   Coffea Documentation <https://coffeateam.github.io/coffea/>
+   Coffea Documentation <https://coffea-hep.readthedocs.io>
 
 
 .. toctree::


### PR DESCRIPTION
I was going through the docs since I'm preparing a talk and I noticed that the Coffea links are outdated and don't work. Some of them don't really matter, but the one that is on the sidebar is actually important.

The notebooks are also outdated and don't work with new versions of Coffea, but that's a task for another day.